### PR TITLE
Fix cache invalidation key ordering

### DIFF
--- a/cline_utils/dependency_system/core/dependency_grid.py
+++ b/cline_utils/dependency_system/core/dependency_grid.py
@@ -272,7 +272,12 @@ def remove_dependency_from_grid(grid: Dict[str, str], source_key: str, target_ke
     new_row = row[:target_idx] + EMPTY_CHAR + row[target_idx + 1:]
     new_grid[source_key] = compress(new_row)
     invalidate_dependent_entries('grid_decompress', f"decompress:{new_grid[source_key]}")
-    invalidate_dependent_entries('grid_validation', f"validate_grid:{hash(str(sorted(new_grid.items())))}:{':'.join(keys)}")
+    # Keys must be consistently ordered for cache invalidation
+    sorted_keys = sort_key_strings_hierarchically(keys)
+    invalidate_dependent_entries(
+        'grid_validation',
+        f"validate_grid:{hash(str(sorted(new_grid.items())))}:{':'.join(sorted_keys)}"
+    )
     return new_grid
 
 # --- Dependency Retrieval ---


### PR DESCRIPTION
## Summary
- ensure hierarchical key order is used in remove_dependency_from_grid

