### PR TITLE
Implement file and dependency caching

### DIFF
--- a/cline_utils/dependency_system/analysis/dependency_analyzer.py
+++ b/cline_utils/dependency_system/analysis/dependency_analyzer.py
@@ -62,10 +62,15 @@ def analyze_file(file_path: str, force: bool = False) -> Dict[str, Any]:
         file_type = util_get_file_type(norm_file_path)
         analysis_result: Dict[str, Any] = {"file_path": norm_file_path, "file_type": file_type, "imports": [], "links": []}
         try:
-            with open(norm_file_path, 'r', encoding='utf-8') as f: content = f.read()
-        except FileNotFoundError: return {"error": "File disappeared during analysis"}
-        except UnicodeDecodeError as e: return {"error": "Encoding error", "details": str(e)}
-        except Exception as e: logger.error(f"Error reading file {norm_file_path}: {e}", exc_info=True); return {"error": "File read error", "details": str(e)}
+            from ..utils import read_file_cached
+            content = read_file_cached(norm_file_path)
+            if content is None:
+                return {"error": "File disappeared during analysis"}
+        except UnicodeDecodeError as e:
+            return {"error": "Encoding error", "details": str(e)}
+        except Exception as e:
+            logger.error(f"Error reading file {norm_file_path}: {e}", exc_info=True)
+            return {"error": "File read error", "details": str(e)}
 
         if file_type == "py": _analyze_python_file(norm_file_path, content, analysis_result)
         elif file_type == "js": _analyze_javascript_file(norm_file_path, content, analysis_result)

--- a/cline_utils/dependency_system/analysis/embedding_manager.py
+++ b/cline_utils/dependency_system/analysis/embedding_manager.py
@@ -172,14 +172,21 @@ def generate_embeddings(project_paths: List[str],
                  logger.warning(f"Path is not a file: {abs_file_path} for key {key_string}. Skipping read.")
                  continue
             try:
-                is_binary = False; # (Binary check unchanged)
+                is_binary = False  # (Binary check unchanged)
                 with open(abs_file_path, 'rb') as f_check:
-                    if b'\0' in f_check.read(1024): is_binary = True
-                if is_binary: logger.debug(f"Skipping binary file: {abs_file_path}"); continue
-                # Read content
-                with open(abs_file_path, 'r', encoding='utf-8') as f: file_contents[key_string] = f.read()
-            except UnicodeDecodeError: logger.debug(f"Skipping non-UTF8 file: {abs_file_path}")
-            except Exception as e: logger.warning(f"Failed to read {abs_file_path}: {e}")
+                    if b'\0' in f_check.read(1024):
+                        is_binary = True
+                if is_binary:
+                    logger.debug(f"Skipping binary file: {abs_file_path}")
+                    continue
+                from ..utils import read_file_cached
+                content = read_file_cached(abs_file_path)
+                if content is not None:
+                    file_contents[key_string] = content
+            except UnicodeDecodeError:
+                logger.debug(f"Skipping non-UTF8 file: {abs_file_path}")
+            except Exception as e:
+                logger.warning(f"Failed to read {abs_file_path}: {e}")
 
         # --- Generate or load embeddings ---
         # <<< *** MODIFIED ITERATION AND CHECKS *** >>>

--- a/cline_utils/dependency_system/core/key_manager.py
+++ b/cline_utils/dependency_system/core/key_manager.py
@@ -15,6 +15,8 @@ import shutil # Added for renaming
 from typing import Dict, List, Tuple, Optional, Set, NamedTuple
 from collections import defaultdict
 
+from cline_utils.dependency_system.utils.cache_manager import cached
+
 # Ensure imports resolve correctly based on project structure
 try:
     from cline_utils.dependency_system.utils.path_utils import get_project_root, normalize_path
@@ -394,6 +396,10 @@ def generate_keys(root_paths: List[str], excluded_dirs: Optional[Set[str]] = Non
     unique_new_keys = list(dict.fromkeys(newly_generated_keys).keys())
     return path_to_key_info, unique_new_keys
 
+@cached(
+    "global_key_map",
+    key_func=lambda: f"global_key_map:{os.path.getmtime(os.path.join(os.path.dirname(os.path.abspath(__file__)), GLOBAL_KEY_MAP_FILENAME)) if os.path.exists(os.path.join(os.path.dirname(os.path.abspath(__file__)), GLOBAL_KEY_MAP_FILENAME)) else 'missing'}"
+)
 def load_global_key_map() -> Optional[Dict[str, KeyInfo]]:
     """
     Loads the persisted global path_to_key_info map from the JSON file
@@ -436,6 +442,10 @@ def load_global_key_map() -> Optional[Dict[str, KeyInfo]]:
         logger.exception(f"Unexpected error loading global key map from {map_path}: {e}")
         return None
 
+@cached(
+    "old_global_key_map",
+    key_func=lambda: f"old_global_key_map:{os.path.getmtime(os.path.join(os.path.dirname(os.path.abspath(__file__)), OLD_GLOBAL_KEY_MAP_FILENAME)) if os.path.exists(os.path.join(os.path.dirname(os.path.abspath(__file__)), OLD_GLOBAL_KEY_MAP_FILENAME)) else 'missing'}"
+)
 def load_old_global_key_map() -> Optional[Dict[str, KeyInfo]]:
     """Loads the persisted PREVIOUS global path_to_key_info map."""
     try:

--- a/cline_utils/dependency_system/utils/__init__.py
+++ b/cline_utils/dependency_system/utils/__init__.py
@@ -1,3 +1,5 @@
-"""
-Utilities package initialization.
-"""
+"""Utilities package initialization."""
+
+from .file_cache import read_file_cached
+
+__all__ = ["read_file_cached"]

--- a/cline_utils/dependency_system/utils/file_cache.py
+++ b/cline_utils/dependency_system/utils/file_cache.py
@@ -1,0 +1,25 @@
+import os
+import logging
+from typing import Optional
+
+from .cache_manager import cached
+from .path_utils import normalize_path
+
+logger = logging.getLogger(__name__)
+
+@cached(
+    "file_contents",
+    key_func=lambda file_path: f"file_contents:{normalize_path(file_path)}:{os.path.getmtime(file_path) if os.path.exists(file_path) else 'missing'}"
+)
+def read_file_cached(file_path: str) -> Optional[str]:
+    """Read a text file with caching based on modification time."""
+    norm_path = normalize_path(file_path)
+    if not os.path.exists(norm_path):
+        logger.debug(f"File not found: {norm_path}")
+        return None
+    try:
+        with open(norm_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except Exception as e:
+        logger.exception(f"Error reading file {norm_path}: {e}")
+        return None


### PR DESCRIPTION
## Summary
- add file cache utility with modification-based invalidation
- use cached reads in dependency analyzer and embedding manager
- cache global key map loading functions
- export `read_file_cached` utility

## Testing
- `python -m py_compile cline_utils/dependency_system/utils/file_cache.py`
- `python -m py_compile cline_utils/dependency_system/analysis/dependency_analyzer.py`
- `python -m py_compile cline_utils/dependency_system/analysis/embedding_manager.py`
- `python -m py_compile cline_utils/dependency_system/core/key_manager.py`
