### PR TITLE
Improve verification with cached reads

### DIFF
--- a/Cache_System_Documentation.md
+++ b/Cache_System_Documentation.md
@@ -94,6 +94,9 @@ def process_file_data(file_id):
 ```
 
 If the underlying file changes, functions like `check_file_modified` can trigger invalidation for caches linked to that file path.
+### Caching File Reads
+`read_file_cached` from `cline_utils.dependency_system.utils.file_utils` returns the contents of a file and stores it in the `file_contents` cache. The cache key includes the file's modification time so cached data updates automatically when the file changes. Use this during pre-action verification to avoid repeated disk reads.
+
 
 #### Manual Invalidation
 

--- a/cline_utils/dependency_system/utils/__init__.py
+++ b/cline_utils/dependency_system/utils/__init__.py
@@ -1,3 +1,3 @@
-"""
-Utilities package initialization.
-"""
+"""Utilities package initialization."""
+
+from .file_utils import read_file_cached

--- a/cline_utils/dependency_system/utils/file_utils.py
+++ b/cline_utils/dependency_system/utils/file_utils.py
@@ -1,0 +1,30 @@
+"""Utility functions for reading files with caching support."""
+
+import os
+from typing import Optional
+
+from .cache_manager import cached
+from .path_utils import normalize_path
+
+
+@cached(
+    "file_contents",
+    key_func=lambda path: f"read_file:{normalize_path(path)}:{os.path.getmtime(path) if os.path.exists(path) else 'na'}",
+    ttl=0,
+)
+def read_file_cached(file_path: str) -> Optional[str]:
+    """Return the content of ``file_path`` using the cache.
+
+    If the file does not exist or cannot be read, ``None`` is returned.
+    The cache key includes the file's modification time so the
+    cached value automatically refreshes when the file changes.
+    """
+    norm_path = normalize_path(file_path)
+    if not os.path.isfile(norm_path):
+        return None
+    try:
+        with open(norm_path, "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception:
+        return None
+


### PR DESCRIPTION
## Summary
- add `read_file_cached` utility for cached file access
- expose `read_file_cached` in utils package
- document cached file reads in cache documentation
- simplify pre-action verification instructions to use cache

## Testing
- `pytest -q` *(fails: command not found)*